### PR TITLE
Open Rooms

### DIFF
--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/__init__.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/__init__.py
@@ -1,5 +1,8 @@
 from ._rooms_client import RoomsClient
-from ._generated.models._enums import RoleType
+from ._generated.models._enums import (
+    RoomJoinPolicy,
+    RoleType
+)
 from ._models import (
     RoomModel,
     RoomParticipant,
@@ -10,6 +13,7 @@ __all__ = [
     'RoomModel',
     'RoomsClient',
     'RoomParticipant',
+    'RoomJoinPolicy',
     'RoleType',
     'ParticipantsCollection'
 ]

--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/_models/_models.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/_models/_models.py
@@ -10,6 +10,7 @@ from .._generated.models import (
     RoomParticipant as RoomParticipantInternal,
     CommunicationIdentifierModel,
     CommunicationUserIdentifierModel,
+    RoomJoinPolicy,
     RoleType
 )
 from .._generated import _serialization
@@ -35,6 +36,8 @@ class RoomModel(_serialization.Model):
     :ivar valid_until: The timestamp from when the room can no longer be joined. The timestamp is
      in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
     :vartype valid_until: ~datetime
+    :ivar room_join_policy: The join policy of the room.
+    :vartype room_join_policy: ~azure.communication.rooms.RoomJoinPolicy
     :ivar participants: Collection of room participants.
     :vartype participants: list[~azure.communication.rooms.RoomParticipant]
     """
@@ -54,6 +57,7 @@ class RoomModel(_serialization.Model):
         created_date_time=None, # type: Optional[datetime]
         valid_from=None, # type: Optional[datetime]
         valid_until=None, # type: Optional[datetime]
+        room_join_policy=None, # type: Optional[RoomJoinPolicy]
         participants=None, # type: Optional[List[RoomParticipant]]
         **kwargs
     ):
@@ -69,6 +73,8 @@ class RoomModel(_serialization.Model):
         :keyword valid_until: The timestamp from when the room can no longer be joined. The timestamp
          is in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
         :paramtype valid_until: ~datetime
+        :keyword room_join_policy: The join policy of the room.
+        :paramtype room_join_policy: ~azure.communication.rooms.RoomJoinPolicy
         :keyword participants: Collection of room participants.
         :paramtype participants: list[~azure.communication.rooms.RoomParticipant]
         """
@@ -77,6 +83,7 @@ class RoomModel(_serialization.Model):
         self.created_date_time = created_date_time
         self.valid_from = valid_from
         self.valid_until = valid_until
+        self.room_join_policy = room_join_policy
         self.participants = participants
 
     @classmethod
@@ -96,6 +103,7 @@ class RoomModel(_serialization.Model):
             created_date_time=get_room_response.created_date_time,
             valid_from=get_room_response.valid_from,
             valid_until=get_room_response.valid_until,
+            room_join_policy=get_room_response.room_join_policy,
             participants=[RoomParticipant.from_room_participant_internal(p) for p in get_room_response.participants],
             **kwargs
         )

--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/_rooms_client.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/_rooms_client.py
@@ -12,14 +12,14 @@ from azure.communication.rooms._models import (
     RoomParticipant,
     ParticipantsCollection
 )
-
 from ._generated._client import AzureCommunicationRoomsService
 from ._generated.models import (
     CreateRoomRequest,
     UpdateRoomRequest,
     RemoveParticipantsRequest,
     AddParticipantsRequest,
-    UpdateParticipantsRequest
+    UpdateParticipantsRequest,
+    RoomJoinPolicy
 )
 
 from ._shared.utils import parse_connection_str, get_authentication_policy
@@ -95,6 +95,7 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         self,
         valid_from=None, # type: Optional[datetime]
         valid_until=None, # type: Optional[datetime]
+        room_join_policy=None, # type: Optional[RoomJoinPolicy]
         participants=None, # type: Optional[List[RoomParticipant]]
         **kwargs
     ):
@@ -107,6 +108,8 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :param valid_until: The timestamp from when the room can no longer be joined. The timestamp
          is in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
         :type valid_until: ~datetime
+        :keyword room_join_policy: (Optional)The join policy of the room.
+        :paramtype room_join_policy: (Optional)RoomJoinPolicy
         :keyword participants: (Optional) Collection of identities invited to the room.
         :paramtype participants: (Optional)list[RoomParticipant]
         :returns: Created room.
@@ -116,6 +119,7 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         create_room_request = CreateRoomRequest(
             valid_from=valid_from,
             valid_until=valid_until,
+            room_join_policy=room_join_policy,
             participants=[p.to_room_participant_internal() for p in participants] if participants else None
         )
 
@@ -153,6 +157,7 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         room_id,
         valid_from=None, # type: Optional[datetime]
         valid_until=None, # type: Optional[datetime]
+        room_join_policy=None, # type: Optional[RoomJoinPolicy]
         participants=None, #type: Optional[List[RoomParticipant]]
         **kwargs
     ):
@@ -167,6 +172,8 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :param valid_until: The timestamp from when the room can no longer be joined. The timestamp
          is in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
         :type valid_until: ~datetime
+        :keyword room_join_policy: (Optional)The join policy of the room.
+        :paramtype room_join_policy: (Optional)RoomJoinPolicy
         :param participants: (Optional) Collection of identities invited to the room.
         :type participants: (Optional)list[RoomParticipant]
         :returns: Updated room.
@@ -174,9 +181,11 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :raises: ~azure.core.exceptions.HttpResponseError, ValueError
 
         """
+
         update_room_request = UpdateRoomRequest(
             valid_from=valid_from,
             valid_until=valid_until,
+            room_join_policy=room_join_policy,
             participants=[p.to_room_participant_internal() for p in participants] if participants else None
         )
         update_room_response = self._rooms_service_client.rooms.update_room(

--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/_rooms_client.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/_rooms_client.py
@@ -172,8 +172,8 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :param valid_until: The timestamp from when the room can no longer be joined. The timestamp
          is in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
         :type valid_until: ~datetime
-        :keyword room_join_policy: (Optional)The join policy of the room.
-        :paramtype room_join_policy: (Optional)RoomJoinPolicy
+        :param room_join_policy: (Optional)The join policy of the room.
+        :type room_join_policy: (Optional)RoomJoinPolicy
         :param participants: (Optional) Collection of identities invited to the room.
         :type participants: (Optional)list[RoomParticipant]
         :returns: Updated room.

--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/aio/_rooms_client_async.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/aio/_rooms_client_async.py
@@ -107,8 +107,8 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :type valid_until: ~datetime
         :param room_join_policy: (Optional)The join policy of the room.
         :type room_join_policy: (Optional)RoomJoinPolicy
-        :keyword participants: (Optional) Collection of identities invited to the room.
-        :paramtype participants: (Optional)List[RoomParticipant]
+        :param participants: (Optional) Collection of identities invited to the room.
+        :type participants: (Optional)List[RoomParticipant]
         :returns: Created room.
         :rtype: ~azure.communication.rooms.RoomModel
         :raises: ~azure.core.exceptions.HttpResponseError

--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/aio/_rooms_client_async.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/aio/_rooms_client_async.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import uuid
 
 from azure.core.tracing.decorator_async import distributed_trace_async
+from azure.communication.rooms import RoomJoinPolicy
 from azure.communication.rooms._models import RoomModel, RoomParticipant, ParticipantsCollection
 from .._generated.aio._client import AzureCommunicationRoomsService
 from .._shared.utils import parse_connection_str, get_authentication_policy
@@ -91,6 +92,7 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         self,
         valid_from=None, # type: Optional[datetime]
         valid_until=None, # type: Optional[datetime]
+        room_join_policy=None, # type: Optional[RoomJoinPolicy]
         participants=None, # type: Optional[List[RoomParticipant]]
         **kwargs
     ):
@@ -103,6 +105,8 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :param valid_until: The timestamp from when the room can no longer be joined. The timestamp
          is in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
         :type valid_until: ~datetime
+        :param room_join_policy: (Optional)The join policy of the room.
+        :type room_join_policy: (Optional)RoomJoinPolicy
         :keyword participants: (Optional) Collection of identities invited to the room.
         :paramtype participants: (Optional)List[RoomParticipant]
         :returns: Created room.
@@ -112,6 +116,7 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         create_room_request = CreateRoomRequest(
             valid_from=valid_from,
             valid_until=valid_until,
+            room_join_policy=room_join_policy,
             participants=[p.to_room_participant_internal() for p in participants] if participants else None
         )
 
@@ -149,7 +154,7 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         room_id,
         valid_from=None, # type: Optional[datetime]
         valid_until=None, # type: Optional[datetime]
-        room_open=None, # type: Optional[bool]
+        room_join_policy=None, # type: Optional[RoomJoinPolicy]
         participants=None, #type: Optional[List[RoomParticipant]]
         **kwargs
     ):
@@ -164,6 +169,8 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :param valid_until: The timestamp from when the room can no longer be joined. The timestamp
          is in RFC3339 format: ``yyyy-MM-ddTHH:mm:ssZ``.
         :type valid_until: ~datetime
+        :param room_join_policy: (Optional)The join policy of the room.
+        :type room_join_policy: (Optional)RoomJoinPolicy
         :param participants: (Optional) Collection of identities invited to the room.
         :type participants: (Optional)list[RoomParticipant]
         :returns: Updated room.
@@ -171,10 +178,11 @@ class RoomsClient(object): # pylint: disable=client-accepts-api-version-keyword
         :raises: ~azure.core.exceptions.HttpResponseError, ValueError
 
         """
+
         update_room_request = UpdateRoomRequest(
             valid_from=valid_from,
             valid_until=valid_until,
-            room_open=room_open,
+            room_join_policy=room_join_policy,
             participants=[p.to_room_participant_internal() for p in participants] if participants else None
         )
         update_room_response = await self._rooms_service_client.rooms.update_room(

--- a/sdk/communication/azure-communication-rooms/swagger/README.md
+++ b/sdk/communication/azure-communication-rooms/swagger/README.md
@@ -30,5 +30,4 @@ title: Azure Communication Rooms Service
 add-credential: false
 v3: true
 no-async: false
-models-mode: msrest
 ```

--- a/sdk/communication/azure-communication-rooms/swagger/README.md
+++ b/sdk/communication/azure-communication-rooms/swagger/README.md
@@ -30,4 +30,5 @@ title: Azure Communication Rooms Service
 add-credential: false
 v3: true
 no-async: false
+models-mode: msrest
 ```

--- a/sdk/communication/azure-communication-rooms/tests/recordings/test_rooms_client_async_e2e.test_update_room_change_open_room_in_past.yaml
+++ b/sdk/communication/azure-communication-rooms/tests/recordings/test_rooms_client_async_e2e.test_update_room_change_open_room_in_past.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-communication-identity/1.1.0 Python/3.10.5 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 08 Jul 2022 18:29:16 GMT
+      x-ms-return-client-request-id:
+      - 'true'
+    method: POST
+    uri: https://sanitized.ppe.communication.azure.net/identities?api-version=2022-06-01
+  response:
+    body:
+      string: '{"error":{"code":"Denied","message":"Denied by the resource provider."}}'
+    headers:
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 Jul 2022 18:29:17 GMT
+      ms-cv:
+      - iZzHmN7ri0CMxo1qAmf75A.0
+      request-context:
+      - appId=
+      strict-transport-security:
+      - max-age=2592000
+      transfer-encoding:
+      - chunked
+      x-cache:
+      - CONFIG_NOCACHE
+      x-processing-time:
+      - 40ms
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/sdk/communication/azure-communication-rooms/tests/recordings/test_rooms_client_e2e.test_update_room_change_open_room_in_past.yaml
+++ b/sdk/communication/azure-communication-rooms/tests/recordings/test_rooms_client_e2e.test_update_room_change_open_room_in_past.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - azsdk-python-communication-identity/1.1.0 Python/3.10.5 (Windows-10-10.0.19044-SP0)
+      x-ms-date:
+      - Fri, 08 Jul 2022 18:23:02 GMT
+      x-ms-return-client-request-id:
+      - 'true'
+    method: POST
+    uri: https://sanitized.ppe.communication.azure.net/identities?api-version=2022-06-01
+  response:
+    body:
+      string: '{"error":{"code":"Denied","message":"Denied by the resource provider."}}'
+    headers:
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 Jul 2022 18:23:03 GMT
+      ms-cv:
+      - 6Kw9ak2h4U2R4E2aw2NYZA.0
+      request-context:
+      - appId=
+      strict-transport-security:
+      - max-age=2592000
+      transfer-encoding:
+      - chunked
+      x-cache:
+      - CONFIG_NOCACHE
+      x-processing-time:
+      - 13ms
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/sdk/communication/azure-communication-rooms/tests/test_rooms_client.py
+++ b/sdk/communication/azure-communication-rooms/tests/test_rooms_client.py
@@ -11,6 +11,7 @@ from azure.core.exceptions import HttpResponseError
 from azure.communication.rooms import (
     RoomsClient,
     RoomParticipant,
+    RoomJoinPolicy,
     RoleType
 )
 from azure.communication.rooms._shared.models import CommunicationUserIdentifier, UnknownIdentifier
@@ -30,6 +31,7 @@ class TestRoomsClient(unittest.TestCase):
     valid_from = datetime.datetime(2022, 2, 25, 4, 34, 0)
     valid_until = datetime.datetime(2022, 4, 25, 4, 34, 0)
     raw_id = "8:acs:abcd"
+    room_join_policy = RoomJoinPolicy.INVITE_ONLY
     room_participant = RoomParticipant(
         communication_identifier=CommunicationUserIdentifier(
             id=raw_id
@@ -53,6 +55,7 @@ class TestRoomsClient(unittest.TestCase):
                 "createdDateTime": "2022-08-28T01:38:19.0359921+00:00",
                 "validFrom": self.valid_from.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 "validUntil": self.valid_until.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "roomJoinPolicy": self.room_join_policy,
                 "participants": [self.json_participant]
             })
 
@@ -62,6 +65,7 @@ class TestRoomsClient(unittest.TestCase):
             response = rooms_client.create_room(
                 valid_from=self.valid_from,
                 valid_until=self.valid_until,
+                room_join_policy=self.room_join_policy,
                 participants=[self.room_participant])
         except:
             raised = True
@@ -71,6 +75,7 @@ class TestRoomsClient(unittest.TestCase):
         self.assertEqual(self.room_id, response.id)
         self.assertEqual(self.valid_from, response.valid_from)
         self.assertEqual(self.valid_until, response.valid_until)
+        self.assertEqual(self.room_join_policy, response.room_join_policy)
         self.assertListEqual([self.room_participant], response.participants)
 
     def test_update_room(self):
@@ -82,6 +87,7 @@ class TestRoomsClient(unittest.TestCase):
                 "createdDateTime": "2022-08-28T01:38:19.0359921+00:00",
                 "validFrom": self.valid_from.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 "validUntil": self.valid_until.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "roomJoinPolicy": self.room_join_policy,
                 "participants": []
             })
 
@@ -91,7 +97,8 @@ class TestRoomsClient(unittest.TestCase):
             response = rooms_client.update_room(
                 room_id=self.room_id,
                 valid_from=self.valid_from,
-                valid_until=self.valid_until)
+                valid_until=self.valid_until,
+                room_join_policy=self.room_join_policy)
         except:
             raised = True
             raise
@@ -100,6 +107,7 @@ class TestRoomsClient(unittest.TestCase):
         self.assertEqual(self.room_id, response.id)
         self.assertEqual(self.valid_from, response.valid_from)
         self.assertEqual(self.valid_until, response.valid_until)
+        self.assertEqual(self.room_join_policy, response.room_join_policy)
         self.assertListEqual(response.participants, [])
 
     def test_delete_room_raises_error(self):
@@ -118,6 +126,7 @@ class TestRoomsClient(unittest.TestCase):
                 "createdDateTime": "2022-08-28T01:38:19.0359921+00:00",
                 "validFrom": self.valid_from.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 "validUntil": self.valid_until.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "roomJoinPolicy": self.room_join_policy,
                 "participants": []
             })
 
@@ -134,6 +143,7 @@ class TestRoomsClient(unittest.TestCase):
         self.assertEqual(self.room_id, response.id)
         self.assertEqual(self.valid_from, response.valid_from)
         self.assertEqual(self.valid_until, response.valid_until)
+        self.assertEqual(self.room_join_policy, response.room_join_policy)
         self.assertListEqual(response.participants, [])
 
     def test_get_room_raises_error(self):

--- a/sdk/communication/azure-communication-rooms/tests/test_rooms_client_async.py
+++ b/sdk/communication/azure-communication-rooms/tests/test_rooms_client_async.py
@@ -10,6 +10,7 @@ from azure.core.credentials import AccessToken
 from azure.communication.rooms.aio import RoomsClient
 from azure.communication.rooms import (
     RoomParticipant,
+    RoomJoinPolicy,
     RoleType
 )
 from azure.communication.rooms._shared.models import CommunicationUserIdentifier, UnknownIdentifier
@@ -28,6 +29,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
     room_id = "999126454"
     valid_from = datetime.datetime(2022, 2, 25, 4, 34, 0)
     valid_until = datetime.datetime(2022, 4, 25, 4, 34, 0)
+    room_join_policy = RoomJoinPolicy.INVITE_ONLY
     raw_id = "8:acs:abcd"
     room_participant = RoomParticipant(
         communication_identifier=CommunicationUserIdentifier(
@@ -52,6 +54,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
                 "createdDateTime": "2022-08-28T01:38:19.0359921+00:00",
                 "validFrom": self.valid_from.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 "validUntil": self.valid_until.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "roomJoinPolicy": self.room_join_policy,
                 "participants": [self.json_participant]
             })
 
@@ -68,6 +71,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
         self.assertEqual(self.room_id, response.id)
         self.assertEqual(self.valid_from, response.valid_from)
         self.assertEqual(self.valid_until, response.valid_until)
+        self.assertEqual(self.room_join_policy, response.room_join_policy)
         self.assertListEqual([self.room_participant], response.participants)
 
     async def test_update_room(self):
@@ -79,6 +83,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
                 "createdDateTime": "2022-08-28T01:38:19.0359921+00:00",
                 "validFrom": self.valid_from.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 "validUntil": self.valid_until.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "roomJoinPolicy": self.room_join_policy,
                 "participants": []
             })
 
@@ -89,7 +94,8 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
             response = await rooms_client.update_room(
                 room_id=self.room_id,
                 valid_from=self.valid_from,
-                valid_until=self.valid_until)
+                valid_until=self.valid_until,
+                room_join_policy=self.room_join_policy)
         except:
             raised = True
             raise
@@ -98,6 +104,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
         self.assertEqual(self.room_id, response.id)
         self.assertEqual(self.valid_from, response.valid_from)
         self.assertEqual(self.valid_until, response.valid_until)
+        self.assertEqual(self.room_join_policy, response.room_join_policy)
         self.assertListEqual(response.participants, [])
 
     async def test_delete_room_raises_error(self):
@@ -120,6 +127,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
                 "createdDateTime": "2022-08-28T01:38:19.0359921+00:00",
                 "validFrom": self.valid_from.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 "validUntil": self.valid_until.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "roomJoinPolicy": self.room_join_policy,
                 "participants": []
             })
 
@@ -136,6 +144,7 @@ class TestRoomsClient(aiounittest.AsyncTestCase):
         self.assertEqual(self.room_id, response.id)
         self.assertEqual(self.valid_from, response.valid_from)
         self.assertEqual(self.valid_until, response.valid_until)
+        self.assertEqual(self.room_join_policy, response.room_join_policy)
         self.assertListEqual(response.participants, [])
 
     async def test_get_room_raises_error(self):


### PR DESCRIPTION
Adding Open Rooms changes for the Create/Update/Get Rooms APIs.

RoomOpen flag was introduced to the Create/Update Request DTOs and also on the RoomModel for when retrieving the room, tests were updated and also added but will not pass until the changes are live in ACS Roooms server and Scheduling Service.